### PR TITLE
fix: replace hardcoded user paths with tilde notation in Claude settings

### DIFF
--- a/.claude/hooks/load-dynamic-requirements.ts
+++ b/.claude/hooks/load-dynamic-requirements.ts
@@ -48,7 +48,7 @@ async function main() {
     const data: HookInput = JSON.parse(input);
     
     // Read the markdown file with instructions from commands directory
-    const mdPath = '/Users/daniel/.claude/commands/load-dynamic-requirements.md';
+    const mdPath = '~/.claude/commands/load-dynamic-requirements.md';
     const mdContent = readFileSync(mdPath, 'utf-8');
     
     // Output the markdown content to stdout

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -119,7 +119,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/load-dynamic-requirements.ts"
+            "command": "bun ~/.claude/hooks/load-dynamic-requirements.ts"
           }
         ]
       }
@@ -129,7 +129,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/session-start-hook.ts"
+            "command": "bun ~/.claude/hooks/session-start-hook.ts"
           }
         ]
       }
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/stop-hook.ts"
+            "command": "bun ~/.claude/hooks/stop-hook.ts"
           }
         ]
       }
@@ -149,7 +149,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/subagent-stop-hook.ts"
+            "command": "bun ~/.claude/hooks/subagent-stop-hook.ts"
           }
         ]
       }
@@ -160,7 +160,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/context-compression-hook.ts"
+            "command": "bun ~/.claude/hooks/context-compression-hook.ts"
           }
         ]
       }
@@ -168,7 +168,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash /Users/daniel/.claude/statusline-command.sh"
+    "command": "bash ~/.claude/statusline-command.sh"
   },
   "feedbackSurveyState": {
     "lastShownTime": 1754071370324

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ ls -lah
 ### **Prerequisites**
 
 - [Claude Code](https://claude.ai/code) - The primary AI interface, which can be any similar system
+- [Bun](https://bun.com/) - Execute commands and hooks
 - Text editor (any will work - it's all Markdown/Text!)
 - Ideal: Basic command line familiarity
 


### PR DESCRIPTION
## Summary
Complete the migration from hardcoded user paths to tilde notation for better portability across different user environments.

## Changes
- Replace hardcoded `/Users/daniel/` paths with `~/` in Claude settings configuration
- Fix remaining hardcoded path in load-dynamic-requirements.ts hook
- Add Bun prerequisite to README documentation

## Impact
- Improves portability for users with different usernames/home directories
- Maintains consistent configuration approach across all hook commands

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>