### PR TITLE
Replace hardcoded paths with PAI_HOME environment variable

### DIFF
--- a/.claude/commands/capture-learning.md
+++ b/.claude/commands/capture-learning.md
@@ -10,10 +10,10 @@ This command captures the full narrative of problem-solving: what we thought was
 
 ```bash
 # Interactive mode - guides you through the narrative
-bun ~/.claude/commands/capture-learning.ts
+bun ${PAI_HOME}/.claude/commands/capture-learning.ts
 
 # Direct mode with full narrative (all 6 arguments)
-bun ~/.claude/commands/capture-learning.ts "problem" "initial assumption" "actual reality" "troubleshooting steps" "solution" "key takeaway"
+bun ${PAI_HOME}/.claude/commands/capture-learning.ts "problem" "initial assumption" "actual reality" "troubleshooting steps" "solution" "key takeaway"
 ```
 
 ## Trigger Phrases
@@ -48,7 +48,7 @@ This narrative approach helps us:
 
 ## Output
 
-Files are saved to: `~/.claude/context/learnings/`
+Files are saved to: `${PAI_HOME}/.claude/context/learnings/`
 
 Named with format: `YYYY-MM-DD-problem-description.md`
 
@@ -96,6 +96,6 @@ The TypeScript implementation for this command is in `capture-learning.ts`.
 
 The command:
 - Prompts for all 6 narrative elements if not provided
-- Creates a structured markdown file in `~/.claude/context/learnings/`
+- Creates a structured markdown file in `${PAI_HOME}/.claude/context/learnings/`
 - Names files with date and problem description
 - Generates a comprehensive learning narrative

--- a/.claude/commands/capture-learning.ts
+++ b/.claude/commands/capture-learning.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
 
-const LEARNINGS_DIR = path.join(process.env.HOME!, '.claude', 'context', 'learnings');
+const LEARNINGS_DIR = path.join(process.env.PAI_HOME!, '.claude', 'context', 'learnings');
 
 // Ensure learnings directory exists
 if (!fs.existsSync(LEARNINGS_DIR)) {

--- a/.claude/commands/load-dynamic-requirements.md
+++ b/.claude/commands/load-dynamic-requirements.md
@@ -6,7 +6,7 @@
 
 You must first initialize the context system with our core context, located at:
 
-`read ~/Context/CLAUDE.md`
+`read ${PAI_HOME}/.claude/Context/CLAUDE.md`
 
 ## 🚨 OVERVIEW: TWO TYPES OF DYNAMIC LOADING
 
@@ -50,7 +50,7 @@ When you receive a user prompt:
 **YOU MUST IMMEDIATELY:**
 
 **CONTEXT FILES:**
-- `~/.claude/context/projects/Alma/CLAUDE.md` ✅
+- `${PAI_HOME}/.claude/context/projects/Alma/CLAUDE.md` ✅
 
 **AGENT:** None
 
@@ -106,8 +106,8 @@ When you receive a user prompt:
 **YOU MUST IMMEDIATELY:**
 
 **CONTEXT FILES:**
-- `~/.claude/context/projects/website/CLAUDE.md` ✅
-- `~/.claude/context/projects/website/content/CLAUDE.md` ✅
+- `${PAI_HOME}/.claude/context/projects/website/CLAUDE.md` ✅
+- `${PAI_HOME}/.claude/context/projects/website/content/CLAUDE.md` ✅
 
 **AGENT:** None
 
@@ -171,7 +171,7 @@ When you receive a user prompt:
 
 **CONTEXT FILES:**
 
-- `~/.claude/context/consulting/CLAUDE.md` ✅
+- `${PAI_HOME}/.claude/context/consulting/CLAUDE.md` ✅
 
 **AGENT:** None
 
@@ -194,8 +194,8 @@ When you receive a user prompt:
 
 **CONTEXT FILES:**
 
-- `~/.claude/context/life/expenses.md` ✅
-- `~/.claude/context/life/finances/` ✅
+- `${PAI_HOME}/.claude/context/life/expenses.md` ✅
+- `${PAI_HOME}/.claude/context/life/finances/` ✅
 
 **AGENT:** None
 
@@ -222,7 +222,7 @@ When you receive a user prompt:
 
 **CONTEXT FILES:**
 
-- `~/.claude/context/unsupervised-learning/CLAUDE.md` ✅
+- `${PAI_HOME}/.claude/context/unsupervised-learning/CLAUDE.md` ✅
 
 **AGENT:** None
 
@@ -245,7 +245,7 @@ When you receive a user prompt:
 
 **CONTEXT FILES:**
 
-- `~/.claude/context/tools/CLAUDE.md` ✅
+- `${PAI_HOME}/.claude/context/tools/CLAUDE.md` ✅
 
 **AGENT:** designer 
 
@@ -271,9 +271,9 @@ When you receive a user prompt:
 **YOU MUST IMMEDIATELY:**
 1. Run the capture-learning command with the problem and solution:
    ```bash
-   bun ~/.claude/commands/capture-learning.ts "[problem description]" "[solution description]"
+   bun ${PAI_HOME}/.claude/commands/capture-learning.ts "[problem description]" "[solution description]"
    ```
-2. The command will create a markdown file in `~/.claude/context/learnings/`
+2. The command will create a markdown file in `${PAI_HOME}/.claude/context/learnings/`
 3. File will be named: `YYYY-MM-DD-HHMM:SS-hyphenated-problem-description-in-8-words.md`
 4. Confirm the learning was captured successfully
 

--- a/.claude/context/CLAUDE.md
+++ b/.claude/context/CLAUDE.md
@@ -40,17 +40,17 @@ The Universal File System Context (UFC) is a hierarchical context management sys
 
 The user_prompt hook under the Claude directory/hooks will dynamically load additional context within the UFC based on what is asked for.
 
-~/.claude/hooks/load-dynamic-context.ts
+${PAI_HOME}/.claude/hooks/load-dynamic-context.ts
 
 ## 📂 Read The Context Directory Structure 
 
 Get the current context directory structure here so you now know where to find additional context if you need it.
 
-`ls ~/.claude/context/`
+`ls ${PAI_HOME}/.claude/context/`
 
 ## Mentions of "context"
 
-Whenever I mention "the context" or, updating context, I am referring to this infrastructure above: ~/.claude/context/
+Whenever I mention "the context" or, updating context, I am referring to this infrastructure above: ${PAI_HOME}/.claude/context/
 
 ## KAI's EYES: BUILDING EDITING AND TESTING WEB APPLICATIONS
 
@@ -62,19 +62,19 @@ THIS IS A CORE PART OF YOUR USEFULNESS!
 
 FOLLOW THE INSTRUCTIONS IN THE PLAYWRIGHT SESSIONS FROM THE 
 
-`~/claude/context/tools/CLAUDE.md` you already loaded!
+`${PAI_HOME}/claude/context/tools/CLAUDE.md` you already loaded!
 
 ## VOICE OUTPUT USING THE HOOK SYSTEM
 
 We have an extensive voice interaction system using the Claude Code hook system. Documentation is here.
 
-``~/.claude/context/documentation/voicesystem/CLAUDE.md``
+``${PAI_HOME}/.claude/context/documentation/voicesystem/CLAUDE.md``
 
 ## TOOLS ARE YOUR FOUNDATION
 
 ## CLAUDE.md hierarchy
 
-This CLAUDE.md, and the ~/.claude/ directory overall is authoritative over your entire Kai DA system.
+This CLAUDE.md, and the ${PAI_HOME}/.claude/ directory overall is authoritative over your entire Kai DA system.
 
 ## Global Stack Preferences
 
@@ -86,7 +86,7 @@ This CLAUDE.md, and the ~/.claude/ directory overall is authoritative over your 
 
 ## Command Creation Rules
 
-- **UNIFIED COMMAND FILES**: When creating new commands in `~/.claude/commands/`, ALWAYS create a single executable .md file with embedded TypeScript code
+- **UNIFIED COMMAND FILES**: When creating new commands in `${PAI_HOME}/.claude/commands/`, ALWAYS create a single executable .md file with embedded TypeScript code
 - **NEVER create separate .ts and .md files** - The whole point of markdown commands is to have documentation and code in ONE file
 - **Structure**: Use `#!/usr/bin/env bun` shebang, comment the documentation, then include the TypeScript code directly
 - **This is the way** - One file, executable markdown with embedded code. No exceptions.
@@ -97,7 +97,7 @@ NEVER EVER
 - Post anything sensitive to a public repo or a location that will be shared publicly in any way!!!
 - **NEVER COMMIT FROM THE WRONG FUCKING DIRECTORY** - ALWAYS verify which repository you're in before committing ANYTHING
 - **CHECK THE FUCKING REMOTE** - Run `git remote -v` BEFORE committing to make sure you're not in a public repo
-- **THE CLAUDE DIRECTORY (~/.claude/) CONTAINS SENSITIVE PRIVATE DATA** - NEVER commit this to ANY public repository
+- **THE CLAUDE DIRECTORY (${PAI_HOME}/.claude/) CONTAINS SENSITIVE PRIVATE DATA** - NEVER commit this to ANY public repository
 - **CHECK THREE TIMES** before running git add or git commit from ANY directory that might be a public repo
 - **ALWAYS COMMIT PROJECT FILES FROM THEIR OWN DIRECTORIES** 
 
@@ -113,7 +113,7 @@ You don't need to explicitly state the date in every response, but always use it
 
 ## /Statusline
 
-Whenever I mention editing my status line, I'm talking about ~/.claude/statusline-command.sh.
+Whenever I mention editing my status line, I'm talking about ${PAI_HOME}/.claude/statusline-command.sh.
 
 And here's the documentation from Anthropic: https://docs.anthropic.com/en/docs/claude-code/statusline
 

--- a/.claude/context/tools/CLAUDE.md
+++ b/.claude/context/tools/CLAUDE.md
@@ -15,7 +15,7 @@ When someone asks you to do ANYTHING, your FIRST thought should be:
 
 ## Web searches
 
-Don't use fetch to research things, use `~/.claude/commands/web-research.md` instead. 
+Don't use fetch to research things, use `${PAI_HOME}/.claude/commands/web-research.md` instead. 
 
 #### 🎭 Playwright MCP Server - Browser Automation & Testing
 
@@ -438,11 +438,11 @@ Task({
 - designer: ZF6FPbjXT488VcRRnw
 - architect: muZKMsIGYtIkjiUS82
 
-## 📁 AVAILABLE COMMANDS (~/.claude/commands/)
+## 📁 AVAILABLE COMMANDS (${PAI_HOME}/.claude/commands/)
 
 **🚨 CHECK THESE FIRST - They solve specific problems completely!**
 
-`read ~/.claude/commands/`
+`read ${PAI_HOME}/.claude/commands/`
 
 Read the descriptions in each of those to understand what they're used for and when you should invoke them.
 
@@ -466,7 +466,7 @@ Examples that should trigger the command:
 
 ## 🔌 MCP SERVERS - Model Context Protocol Services
 
-## Your full list of MCP servers is in `read Users/daniel/.claude/.mcp.json`.
+## Your full list of MCP servers is in `read ${PAI_HOME}/.claude/.mcp.json`.
 
 Read the descriptions in each of those to understand what they're used for and when you should invoke them.
 

--- a/.claude/hooks/load-dynamic-requirements.ts
+++ b/.claude/hooks/load-dynamic-requirements.ts
@@ -48,11 +48,13 @@ async function main() {
     const data: HookInput = JSON.parse(input);
     
     // Read the markdown file with instructions from commands directory
-    const mdPath = '/Users/daniel/.claude/commands/load-dynamic-requirements.md';
+    const homeDir = process.env.PAI_HOME || process.env.HOME || '~';
+    const mdPath = join(homeDir, '.claude/commands/load-dynamic-requirements.md');
     const mdContent = readFileSync(mdPath, 'utf-8');
     
     // Output the markdown content to stdout
     // This will be passed to Claude as instructions
+    console.log("\nIMPORTANT: Variable $PAI_HOME =  "+ homeDir + "\n");
     console.log(mdContent);
     
     // Also output a special marker to indicate this is a hook instruction

--- a/.claude/learnings/2025-09-09-commands-in-claude-commands-needed-proper-markdown.md
+++ b/.claude/learnings/2025-09-09-commands-in-claude-commands-needed-proper-markdown.md
@@ -1,4 +1,4 @@
-# Learning: Commands in ~/.claude/commands/ needed proper markdown-first structure
+# Learning: Commands in ${PAI_HOME}/.claude/commands/ needed proper markdown-first structure
 
 **Date:** Tuesday, September 9, 2025
 
@@ -10,7 +10,7 @@
 
 ### The Problem We Encountered
 
-Commands in ~/.claude/commands/ needed proper markdown-first structure
+Commands in ${PAI_HOME}/.claude/commands/ needed proper markdown-first structure
 
 ### What We Initially Thought
 
@@ -40,7 +40,7 @@ This solution addressed the actual problem rather than what we initially thought
 
 ## 🎯 The Lesson Learned
 
-**So now we know:** Markdown command files in ~/.claude/commands/ should have a .md file for documentation and a separate .ts file for implementation - this provides clear narrative-first documentation while maintaining executable functionality
+**So now we know:** Markdown command files in ${PAI_HOME}/.claude/commands/ should have a .md file for documentation and a separate .ts file for implementation - this provides clear narrative-first documentation while maintaining executable functionality
 
 This changes how we approach similar problems in the future because we understand the underlying mechanism better.
 
@@ -52,7 +52,7 @@ This changes how we approach similar problems in the future because we understan
 
 **After:** We know markdown command files need separate .md documentation and .ts implementation files - bun can't exec...
 
-**Action:** Markdown command files in ~/.claude/commands/ should have a .md file for documentation and a separate .ts file for implementation - this provides clear narrative-first documentation while maintaining executable functionality
+**Action:** Markdown command files in ${PAI_HOME}/.claude/commands/ should have a .md file for documentation and a separate .ts file for implementation - this provides clear narrative-first documentation while maintaining executable functionality
 
 ---
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -119,7 +119,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/load-dynamic-requirements.ts"
+            "command": "bun ${PAI_HOME:-~}/.claude/hooks/load-dynamic-requirements.ts"
           }
         ]
       }
@@ -129,7 +129,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/session-start-hook.ts"
+            "command": "bun ${PAI_HOME:-~}/.claude/hooks/session-start-hook.ts"
           }
         ]
       }
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/stop-hook.ts"
+            "command": "bun ${PAI_HOME:-~}/.claude/hooks/stop-hook.ts"
           }
         ]
       }
@@ -149,7 +149,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/subagent-stop-hook.ts"
+            "command": "bun ${PAI_HOME:-~}/.claude/hooks/subagent-stop-hook.ts"
           }
         ]
       }
@@ -160,7 +160,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun /Users/daniel/.claude/hooks/context-compression-hook.ts"
+            "command": "bun ${PAI_HOME:-~}/.claude/hooks/context-compression-hook.ts"
           }
         ]
       }
@@ -168,7 +168,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash /Users/daniel/.claude/statusline-command.sh"
+    "command": "bash ${PAI_HOME:-~}/.claude/statusline-command.sh"
   },
   "feedbackSurveyState": {
     "lastShownTime": 1754071370324

--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ ls -lah
 
 ```
 
+### **Testing PAI in Custom Locations**
+
+PAI uses the `PAI_HOME` environment variable to determine its installation path. By default, it uses `~/.claude/`, but you can test PAI in any directory:
+
+```bash
+# Test PAI in a custom directory
+export PAI_HOME="/path/to/your/test/directory"
+
+# The system will look for context files at ${PAI_HOME}/.claude/context/
+```
+
+**Important Notes:**
+- Set `PAI_HOME` before starting Claude Code for the environment variable to take effect
+- The `.claude` directory structure should exist at your custom `PAI_HOME` location
+- This is particularly useful for developers testing multiple PAI configurations
+
 ### **Prerequisites**
 
 - [Claude Code](https://claude.ai/code) - The primary AI interface, which can be any similar system


### PR DESCRIPTION
## Summary

  Replace all hardcoded paths with configurable `PAI_HOME` environment
  variable for better deployment flexibility and testing.

  This PR addresses the hardcoded path issue by:
  - Replacing `~/.claude/` references with `${PAI_HOME}/.claude/` throughout
  the codebase
  - Updating commands, hooks, settings, and documentation to use the
  environment variable
  - Adding fallback support `${PAI_HOME:-~}` in hook configurations
  - Documenting the `PAI_HOME` usage in README for custom directory testing

  ## Background

  Two other PRs have addressed similar hardcoded path issues, but this PR
  provides the additional benefit of allowing users to change the default
  installation directory via environment variable configuration.