### PR TITLE
Update MCP configuration and statusline to use dynamic MCP listing

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -27,9 +27,7 @@ if [ -d "$claude_dir/commands" ]; then
 fi
 
 # Count MCPs from settings.json
-if [ -f "$claude_dir/settings.json" ]; then
-    mcps_count=$(jq -r '.mcpServers | keys | length' "$claude_dir/settings.json" 2>/dev/null || echo "0")
-fi
+mcps_count=$(claude mcp list | grep ✓ | wc -l | tr -d ' ' 2>/dev/null || echo "0")
 
 # Count Services from FoundryServices directory
 services_dir="/Users/daniel/Projects/FoundryServices/Services"
@@ -117,32 +115,30 @@ RESET='\033[0m'                      # Reset all formatting
 
 # Get MCP names for line 2 with blue color scheme
 mcp_names_formatted=""
-if [ -f "$claude_dir/settings.json" ]; then
-    mcp_names_raw=$(jq -r '.mcpServers | keys[]' "$claude_dir/settings.json" 2>/dev/null | tr '\n' ' ')
-    # Format MCP names - line 2 blue scheme with accent colors for important ones
-    for mcp in $mcp_names_raw; do
-        case "$mcp" in
-            "daemon") formatted="${MCP_DAEMON}Daemon${RESET}" ;;             # Bright blue accent: Personal API
-            "stripe") formatted="${MCP_STRIPE}Stripe${RESET}" ;;             # Blue accent: Financial ops
-            # All other MCPs use line 2 blue
-            "httpx") formatted="${MCP_DEFAULT}HTTPx${RESET}" ;;
-            "brightdata") formatted="${MCP_DEFAULT}BrightData${RESET}" ;;
-            "naabu") formatted="${MCP_DEFAULT}Naabu${RESET}" ;;
-            "apify") formatted="${MCP_DEFAULT}Apify${RESET}" ;;
-            "content") formatted="${MCP_DEFAULT}Content${RESET}" ;;
-            "Ref") formatted="${MCP_DEFAULT}Ref${RESET}" ;;
-            "pai") formatted="${MCP_DEFAULT}Foundry${RESET}" ;;
-            "playwright") formatted="${MCP_DEFAULT}Playwright${RESET}" ;;
-            *) formatted="${MCP_DEFAULT}${mcp^}${RESET}" ;;                  # Capitalize first letter, line 2 blue
-        esac
-        
-        if [ -z "$mcp_names_formatted" ]; then
-            mcp_names_formatted="$formatted"
-        else
-            mcp_names_formatted="$mcp_names_formatted${SEPARATOR_COLOR}, ${formatted}"
-        fi
-    done
-fi
+mcp_names_raw=$(claude mcp list 2>/dev/null | grep -v "Checking MCP server health" | cut -d':' -f1 | tr '\n' ' ')
+# Format MCP names - line 2 blue scheme with accent colors for important ones
+for mcp in $mcp_names_raw; do
+    case "$mcp" in
+        "daemon") formatted="${MCP_DAEMON}Daemon${RESET}" ;;             # Bright blue accent: Personal API
+        "stripe") formatted="${MCP_STRIPE}Stripe${RESET}" ;;             # Blue accent: Financial ops
+        # All other MCPs use line 2 blue
+        "httpx") formatted="${MCP_DEFAULT}HTTPx${RESET}" ;;
+        "brightdata") formatted="${MCP_DEFAULT}BrightData${RESET}" ;;
+        "naabu") formatted="${MCP_DEFAULT}Naabu${RESET}" ;;
+        "apify") formatted="${MCP_DEFAULT}Apify${RESET}" ;;
+        "content") formatted="${MCP_DEFAULT}Content${RESET}" ;;
+        "Ref") formatted="${MCP_DEFAULT}Ref${RESET}" ;;
+        "pai") formatted="${MCP_DEFAULT}Foundry${RESET}" ;;
+        "playwright") formatted="${MCP_DEFAULT}Playwright${RESET}" ;;
+        *) formatted="${MCP_DEFAULT}${mcp^}${RESET}" ;;                  # Capitalize first letter, line 2 blue
+    esac
+
+    if [ -z "$mcp_names_formatted" ]; then
+        mcp_names_formatted="$formatted"
+    else
+        mcp_names_formatted="$mcp_names_formatted${SEPARATOR_COLOR}, ${formatted}"
+    fi
+done
 
 # Output the line-based color themed statusline
 # Light blue color for directory


### PR DESCRIPTION
#   Summary

  Updated statusline script to use claude mcp list instead of directly parsing settings.json, enabling detection of
  MCP servers configured through any of Claude Code's supported configuration methods.

## Background

  Claude Code supports multiple ways to configure MCP servers beyond just settings.json:

  - Global settings.json - System-wide configurations
  - Local .mcp.json - Project-specific configurations
  - Environment variables - Runtime configurations
  - Command-line parameters - Dynamic configurations
  - Configuration merging - Combinations of above methods

  The previous implementation only detected MCPs in settings.json, missing servers configured through other methods.

## Changes

  - Replace jq parsing of settings.json with claude mcp list command
  - Update MCP count detection to use live status from Claude Code CLI
  - Maintain existing color formatting and display logic

## Benefits

  - Complete Detection: Shows all active MCP servers regardless of configuration method
  - Future-Proof: Automatically supports new MCP configuration approaches
  - Real-Time Status: Reflects actual MCP server health and availability