### PR TITLE
Fix hardcoded paths to use environment variables

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -15,7 +15,7 @@ dir_name=$(basename "$current_dir")
 # - Commands from ~/.claude/commands/
 # - MCPs from settings.json
 # - Patterns from ~/.config/fabric/patterns
-claude_dir="/Users/daniel/.claude"
+claude_dir="${PAI_HOME:-~}/.claude"
 commands_count=0
 mcps_count=0
 fobs_count=0
@@ -38,7 +38,7 @@ if [ -d "$services_dir" ]; then
 fi
 
 # Count Fabric patterns from ~/.config/fabric/patterns
-fabric_patterns_dir="/Users/daniel/.config/fabric/patterns"
+fabric_patterns_dir="$HOME/.config/fabric/patterns"
 if [ -d "$fabric_patterns_dir" ]; then
     fabric_count=$(find "$fabric_patterns_dir" -maxdepth 1 -type d ! -path "$fabric_patterns_dir" 2>/dev/null | wc -l | tr -d ' ')
 fi

--- a/.claude/voice-server/macos-service/com.paivoice.server.plist
+++ b/.claude/voice-server/macos-service/com.paivoice.server.plist
@@ -9,7 +9,7 @@
     <array>
         <string>/usr/local/bin/bun</string>
         <string>run</string>
-        <string>/Users/daniel/.claude/voice-server/server.ts</string>
+        <string>${PAI_HOME}/.claude/voice-server/server.ts</string>
     </array>
     
     <key>EnvironmentVariables</key>
@@ -19,11 +19,10 @@
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>HOME</key>
-        <string>/Users/daniel</string>
     </dict>
     
     <key>WorkingDirectory</key>
-    <string>/Users/daniel/.claude/voice-server</string>
+    <string>${PAI_HOME}/.claude/voice-server</string>
     
     <key>RunAtLoad</key>
     <true/>
@@ -37,10 +36,10 @@
     </dict>
     
     <key>StandardOutPath</key>
-    <string>/Users/daniel/.claude/voice-server/logs/voice-server.log</string>
+    <string>${PAI_HOME}/.claude/voice-server/logs/voice-server.log</string>
     
     <key>StandardErrorPath</key>
-    <string>/Users/daniel/.claude/voice-server/logs/voice-server-error.log</string>
+    <string>${PAI_HOME}/.claude/voice-server/logs/voice-server-error.log</string>
     
     <key>ThrottleInterval</key>
     <integer>10</integer>

--- a/.claude/voice-server/start.sh
+++ b/.claude/voice-server/start.sh
@@ -15,7 +15,7 @@ pkill -f "voice-server/server.ts" 2>/dev/null
 
 # Start the server
 echo "🚀 Starting PAIVoice Server on port $PORT"
-cd /Users/daniel/.claude/voice-server
+cd "${PAI_HOME:-~}/.claude/voice-server"
 bun run server.ts &
 
 echo "✅ Voice server started with PID $!"


### PR DESCRIPTION
Replace hardcoded user paths with PAI_HOME and HOME variables for better portability across different user environments.